### PR TITLE
Add User entity and UserRepository with database table creation

### DIFF
--- a/backend/src/main/java/com/mynetrunner/backend/model/User.java
+++ b/backend/src/main/java/com/mynetrunner/backend/model/User.java
@@ -1,0 +1,40 @@
+package com.mynetrunner.backend.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(unique = true, nullable = false, length = 50)
+    private String username;
+    
+    @Column(nullable = false)
+    private String passwordHash;
+    
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+    
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/mynetrunner/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/mynetrunner/backend/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.mynetrunner.backend.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.mynetrunner.backend.model.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    boolean existsByUsername(String username);
+}


### PR DESCRIPTION
## Summary
Created User entity and UserRepository to enable user data persistence in PostgreSQL.

## Changes Made
- ✅ Created `User` entity with fields:
  - `id` (auto-generated primary key)
  - `username` (unique, max 50 characters)
  - `passwordHash` (stores hashed password)
  - `createdAt` (timestamp, auto-set on creation)
- ✅ Created `UserRepository` interface extending JpaRepository
- ✅ Added methods: `findByUsername()` and `existsByUsername()`
- ✅ Verified database table creation in PostgreSQL

## Database Schema
The `users` table was successfully created with:
- Primary key constraint on `id`
- Unique constraint on `username`
- NOT NULL constraints on all fields

## Testing Done
- ✅ Application starts successfully without errors
- ✅ Hibernate created `users` table in PostgreSQL
- ✅ Verified table structure using `psql`
- ✅ UserRepository detected by Spring Data JPA

## Next Steps
After merging, the next task will be implementing `UserService` for registration and login logic.